### PR TITLE
Support python 2.7

### DIFF
--- a/logger/raven_logger.py
+++ b/logger/raven_logger.py
@@ -101,7 +101,7 @@ class LoggerClient:
         # add ENV vars and stderr if provided
         extra = {}
         if shell_args.env:
-            extra['environment'] = dict([item.split('=', maxsplit=1) for item in shell_args.env.split('\n')])
+            extra['environment'] = dict([item.split('=', 1) for item in shell_args.env.split('\n')])
 
         if shell_args.stderr:
             extra['stderr'] = shell_args.stderr

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='viktor@stiskala.cz',
     url='https://github.com/hareevs/raven-bash',
     license='Apache License 2.0',
-    install_requires=['raven>=5.1.1'],
+    install_requires=['raven>=5.1.1', 'configparser'],
     packages=['logger'],
     package_data={'logger': ['raven-bash', 'logger/*.py']},
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 import sys
 from setuptools import setup
 
-if sys.version_info[:2] < (3, 1):
-    sys.exit('raven-bash requires Python 3.1 or higher.')
-
 long_description = '''\
 Raven Sentry client for Bash.
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     keywords='raven sentry bash',
-    author='Viktor Stískala',
+    author='Viktor Stiskala',
     author_email='viktor@stiskala.cz',
     url='https://github.com/hareevs/raven-bash',
     license='Apache License 2.0',


### PR DESCRIPTION
Hi!

I cloned this and tried to get it to work on Python 2.7 for issue #1 - the only real issue seemed to be with the use of  keyword arguments in the 'split' method. After fixing that, I was able to successfully send errors to Sentry.

Would you please consider merging this?

Thanks!
