### PR TITLE
Improve Stderr passing

### DIFF
--- a/logger/raven_logger.py
+++ b/logger/raven_logger.py
@@ -104,7 +104,10 @@ class LoggerClient:
             extra['environment'] = dict([item.split('=', maxsplit=1) for item in shell_args.env.split('\n')])
 
         if shell_args.stderr:
-            extra['stderr'] = shell_args.stderr
+            # raven only accepts some number of list items
+            #  but you probably want the end of the message
+            stderr_list = shell_args.stderr.splitlines()[-self._client.list_max_length:]
+            extra['stderr'] = stderr_list
 
         self._client.capture('raven.events.Exception', data=data, extra=extra)
 

--- a/logger/raven_logger.py
+++ b/logger/raven_logger.py
@@ -11,8 +11,8 @@ CONFIG_FILE = '/etc/raven-bash.conf'
 
 
 class LoggerClient:
-    def __init__(self, dsn):
-        self._client = Client(dsn=dsn, context={})
+    def __init__(self, dsn, release):
+        self._client = Client(dsn=dsn, context={}, release=release)
 
     def _process_sourcefile(self, file_path, line_number, context_lines=10):
         FileContext = namedtuple('FileContext', ['pre_context', 'context', 'post_context', 'local_vars'])
@@ -122,6 +122,11 @@ def main():
         sys.stderr.write('Missing SENTRY_DSN config from {}\n'.format(CONFIG_FILE))
         sys.exit(1)
 
+    try:
+        release = os.environ['SENTRY_RELEASE']
+    except KeyError:
+        release = ''
+
     parser = argparse.ArgumentParser(description='Send error to Sentry')
 
     parser.add_argument('--env', help='Script environment')
@@ -137,7 +142,7 @@ def main():
 
     args = parser.parse_args()
 
-    client = LoggerClient(dsn)
+    client = LoggerClient(dsn, release)
     client.capture(args)
 
 if __name__ == '__main__':

--- a/raven-bash
+++ b/raven-bash
@@ -7,7 +7,9 @@ exec 4>&2
 exec 2>"$STDERR_TEMPFILE"
 
 logger_trap() {
-    raven-logger "$1" "$3" "$2" --env "`env`" --stderr "`cat $STDERR_TEMPFILE`" --pwd "`pwd`" --function "$5" --declares "`declare -p`" > /dev/null
+    local COMMAND=${RAVEN_CONTEXT:-$1}
+
+    raven-logger "$1" "$COMMAND" "$2" --env "`env`" --stderr "`cat $STDERR_TEMPFILE`" --pwd "`pwd`" --function "$5" --declares "`declare -p`" > /dev/null
     cat "$STDERR_TEMPFILE" 1>&2
     rm -f "$STDERR_TEMPFILE"
 }

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='viktor@stiskala.cz',
     url='https://github.com/hareevs/raven-bash',
     license='Apache License 2.0',
-    install_requires=['raven>=5.1.1'],
+    install_requires=['raven==5.1.1'],
     packages=['logger'],
     package_data={'logger': ['raven-bash', 'logger/*.py']},
     entry_points={


### PR DESCRIPTION
Because Sentry truncates strings at [client.max_string_length](https://docs.sentry.io/clients/python/advanced/) (default 400 {yes it says 200...})
And often the stderr may be longer than that, thus take the string split it by line and return that as a list instead.